### PR TITLE
Add STAR voting

### DIFF
--- a/play/css/election.css
+++ b/play/css/election.css
@@ -11,8 +11,9 @@ Election/Sandbox design:
 	height: 320px;
 }
 #left{
-	width:220px;
+	width:227px;
 	padding-right: 20px;
+	overflow-y: scroll;
 }
 #center{
 	width:320px;
@@ -58,7 +59,7 @@ Election/Sandbox design:
     text-align: center;
     margin-bottom: 5px;
     padding: 2px 0;
-    
+
     position: relative;
     top:0;
 

--- a/play/js/Election.js
+++ b/play/js/Election.js
@@ -266,7 +266,7 @@ Election.irv = function(model, options){
 
 		// And repeat!
 		roundNum++;
-	
+
 	}
 
 	// END!
@@ -317,6 +317,70 @@ Election.plurality = function(model, options){
 
 };
 
+Election.star = function(model, options){
+
+	var text = "";
+	text += "<span class='small'>";
+
+	var candidates = [];
+	for(var i=0; i<model.candidates.length; i++){
+		candidates.push(model.candidates[i].id);
+	}
+
+	text += "<b>round 1:</b><br>";
+	text += "who are the top two choices?<br>";
+
+	// Tally the approvals & get the top two!
+	var tally = _tally(model, function(tally, ballot){
+		for(var candidate in ballot){
+			tally[candidate] += ballot[candidate];
+		}
+	});
+	for(var candidate in tally){
+		tally[candidate] /= model.getTotalVoters();
+	}
+	var topTwo = _countTopTwo(tally); // [frontRunner, runnerUp]
+
+	// Say 'em...
+	for(var i=0; i<topTwo.length; i++){
+		var c = topTwo[i];
+		text += _icon(c)+":"+tally[c];
+		if(i<topTwo.length-1) text+=", ";
+	}
+	text += "<br>";
+
+	// Determine winner
+	text += "<b>round 2:</b><br>";
+	text += "who is ranked higher?<br>";
+
+	var highestScore = topTwo[0];
+	var secondHighest = topTwo[1];
+
+	var ballots = model.getBallots();
+
+	var firstWins = 0;
+	var secondWins = 0;
+	for(var i=0; i<ballots.length-1; i++){
+		var rank = ballots[i].rank;
+		if(rank.indexof(highestScore.id)<rank.indexOf(secondHighest.id)){
+			firstWins++;
+		}else{
+			secondWins++;
+		}
+	}
+
+	// WINNER?
+	var winner = (firstWins>secondWins) ? highestScore : secondHighest;
+
+	// END!
+	var color = _colorWinner(model, winner);
+	text += "</span>";
+	text += "<br>";
+	text += "<b style='color:"+color+"'>"+winner.toUpperCase()+"</b> WINS";
+	model.caption.innerHTML = text;
+
+};
+
 var _tally = function(model, tallyFunc){
 
 	// Create the tally
@@ -328,7 +392,7 @@ var _tally = function(model, tallyFunc){
 	for(var i=0; i<ballots.length; i++){
 		tallyFunc(tally, ballots[i]);
 	}
-	
+
 	// Return it.
 	return tally;
 
@@ -350,6 +414,29 @@ var _countWinner = function(tally){
 	}
 
 	return winner;
+
+}
+
+// Returns the two highest scoring candidates
+var _countTopTwo = function(tally){
+
+	// TO DO: TIES as an array?!?!
+
+	var highScore = -1
+	var firstPlace = null;
+	var secondPlace = null;
+
+	for(var candidate in tally){
+		var score = tally[candidate];
+		if(score>firstPlace){
+			secondPlace = firstPlace;
+			firstPlace = score;
+		}else if(score>secondPlace){
+			secondPlace = score;
+		}
+	}
+
+	return [firstPlace, secondPlace];
 
 }
 

--- a/play/js/Election.js
+++ b/play/js/Election.js
@@ -339,7 +339,7 @@ Election.star = function(model, options){
 	for(var candidate in tally){
 		tally[candidate] /= model.getTotalVoters();
 	}
-	var topTwo = _countTopTwo(tally); // [frontRunner, runnerUp]
+	var topTwo = _countTopTwo(tally); // [firstPlace, secondPlace]
 
 	// Say 'em...
 	for(var i=0; i<topTwo.length; i++){
@@ -353,24 +353,23 @@ Election.star = function(model, options){
 	text += "<b>round 2:</b><br>";
 	text += "who is ranked higher?<br>";
 
-	var highestScore = topTwo[0];
-	var secondHighest = topTwo[1];
+	var firstPlace = topTwo[0];
+	var secondPlace = topTwo[1];
 
 	var ballots = model.getBallots();
 
 	var firstWins = 0;
 	var secondWins = 0;
 	for(var i=0; i<ballots.length-1; i++){
-		var rank = ballots[i].rank;
-		if(rank.indexof(highestScore.id)<rank.indexOf(secondHighest.id)){
+		if(ballots[i][firstPlace]>ballots[i][secondPlace]){
 			firstWins++;
-		}else{
+		}else if(ballots[i][firstPlace]<ballots[i][secondPlace]){
 			secondWins++;
 		}
 	}
 
 	// WINNER?
-	var winner = (firstWins>secondWins) ? highestScore : secondHighest;
+	var winner = (firstWins>secondWins) ? firstPlace : secondPlace;
 
 	// END!
 	var color = _colorWinner(model, winner);
@@ -422,17 +421,21 @@ var _countTopTwo = function(tally){
 
 	// TO DO: TIES as an array?!?!
 
-	var highScore = -1
+	var highestScore = -1
+	var secondHighest = -1;
 	var firstPlace = null;
 	var secondPlace = null;
 
 	for(var candidate in tally){
 		var score = tally[candidate];
-		if(score>firstPlace){
-			secondPlace = firstPlace;
-			firstPlace = score;
-		}else if(score>secondPlace){
-			secondPlace = score;
+		if(score>highestScore){
+			secondHighest = highestScore;
+			secondPlace = candidate;
+			highestScore = score;
+			firstPlace = candidate;
+		}else if(score>secondHighest){
+			secondHighest = score;
+			secondPlace = candidate;
 		}
 	}
 

--- a/play/js/Election.js
+++ b/play/js/Election.js
@@ -349,7 +349,7 @@ Election.star = function(model, options){
 
 	// Determine winner
 	text += "<b>round 2:</b><br>";
-	text += "who is ranked higher?<br>";
+	text += "who is ranked higher (ties excluded)?<br>";
 
 	var firstPlace = topTwo[0];
 	var secondPlace = topTwo[1];
@@ -358,7 +358,7 @@ Election.star = function(model, options){
 
 	var firstWins = 0;
 	var secondWins = 0;
-	for(var i=0; i<ballots.length-1; i++){
+	for(var i=0; i<ballots.length; i++){
 		if(ballots[i][firstPlace]>ballots[i][secondPlace]){
 			firstWins++;
 		}else if(ballots[i][firstPlace]<ballots[i][secondPlace]){

--- a/play/js/Election.js
+++ b/play/js/Election.js
@@ -344,10 +344,8 @@ Election.star = function(model, options){
 	// Say 'em...
 	for(var i=0; i<topTwo.length; i++){
 		var c = topTwo[i];
-		text += _icon(c)+":"+tally[c];
-		if(i<topTwo.length-1) text+=", ";
+		text += _icon(c)+"'s score: "+(tally[c].toFixed(2))+" out of 5.00<br>";
 	}
-	text += "<br>";
 
 	// Determine winner
 	text += "<b>round 2:</b><br>";
@@ -370,6 +368,18 @@ Election.star = function(model, options){
 
 	// WINNER?
 	var winner = (firstWins>secondWins) ? firstPlace : secondPlace;
+
+	// Text
+	var by,to;
+	if(winner==firstPlace){
+		by = firstWins;
+		to = secondWins;
+	}else{
+		by = secondWins;
+		to = firstWins;
+	}
+	text += _icon(firstPlace)+" vs "+_icon(secondPlace)+": "+_icon(winner)+" wins by "+by+" to "+to+"<br>";
+
 
 	// END!
 	var color = _colorWinner(model, winner);

--- a/play/js/Election.js
+++ b/play/js/Election.js
@@ -339,7 +339,7 @@ Election.star = function(model, options){
 	for(var candidate in tally){
 		tally[candidate] /= model.getTotalVoters();
 	}
-	var topTwo = _countTopTwo(tally); // [firstPlace, secondPlace]
+	var topTwo = _countTopN(tally, 2); // [firstPlace, secondPlace]
 
 	// Say 'em...
 	for(var i=0; i<topTwo.length; i++){
@@ -426,31 +426,10 @@ var _countWinner = function(tally){
 
 }
 
-// Returns the two highest scoring candidates
-var _countTopTwo = function(tally){
-
-	// TO DO: TIES as an array?!?!
-
-	var highestScore = -1
-	var secondHighest = -1;
-	var firstPlace = null;
-	var secondPlace = null;
-
-	for(var candidate in tally){
-		var score = tally[candidate];
-		if(score>highestScore){
-			secondHighest = highestScore;
-			secondPlace = candidate;
-			highestScore = score;
-			firstPlace = candidate;
-		}else if(score>secondHighest){
-			secondHighest = score;
-			secondPlace = candidate;
-		}
-	}
-
-	return [firstPlace, secondPlace];
-
+// Returns the n highest scoring candidates
+var _countTopN = function(tally, n){
+	var sorted = Object.keys(tally).sort(function(a,b){return tally[b]-tally[a]});
+	return sorted.slice(0, n);
 }
 
 var _countLoser = function(tally){

--- a/play/js/main_sandbox.js
+++ b/play/js/main_sandbox.js
@@ -122,7 +122,7 @@ function main(config){
 		var setInPosition = function(){
 
 			var positions;
-			
+
 			// CANDIDATE POSITIONS
 			positions = config.candidatePositions;
 			if(positions){
@@ -162,7 +162,8 @@ function main(config){
 			{name:"Borda", voter:RankedVoter, election:Election.borda, margin:4},
 			{name:"Condorcet", voter:RankedVoter, election:Election.condorcet},
 			{name:"Approval", voter:ApprovalVoter, election:Election.approval, margin:4},
-			{name:"Score", voter:ScoreVoter, election:Election.score}
+			{name:"Score", voter:ScoreVoter, election:Election.score},
+			{name:"STAR", voter:ScoreVoter, election:Election.star, margin:4}
 		];
 		var onChooseSystem = function(data){
 
@@ -279,14 +280,14 @@ function main(config){
 		resetDOM.style.top = "340px";
 		resetDOM.style.left = "350px";
 		resetDOM.onclick = function(){
-			
+
 			config = JSON.parse(JSON.stringify(initialConfig)); // RESTORE IT!
 
 			// Reset manually, coz update LATER.
 			model.reset(true);
 			model.onInit();
 			setInPosition();
-			
+
 			// Back to ol' UI
 			selectUI();
 
@@ -383,7 +384,7 @@ function main(config){
 			// save... ?d={s:[system], v:[voterPositions], c:[candidatePositions], d:[description]}
 
 		}
-		
+
 
 	};
 
@@ -410,7 +411,7 @@ function main(config){
 		// Positions...
 		var positions = save(true);
 		data.v = positions.voterPositions;
-		data.c = positions.candidatePositions; 
+		data.c = positions.candidatePositions;
 
 		// Description
 		var description = document.getElementById("description_text");


### PR DESCRIPTION
Here's an explanation of STAR voting: https://www.equal.vote/starvoting
This PR addresses this issue: https://github.com/ncase/ballot/issues/15

I wasn't sure what the best way to add another voting option was, so I decided to use a vertical scroll for the overflow. Let me know if you would prefer something else.
<img width="819" alt="screen shot 2018-06-09 at 12 30 02 am" src="https://user-images.githubusercontent.com/1513221/41187749-1154b7b8-6b7f-11e8-90cb-6657f4a39a49.png">
<img width="823" alt="screen shot 2018-06-09 at 12 30 12 am" src="https://user-images.githubusercontent.com/1513221/41187750-16468f76-6b7f-11e8-8972-bff8573de6f6.png">

STAR voting matches Score voting in almost all cases. But here's an example of where they differ:
<img width="819" alt="screen shot 2018-06-09 at 12 45 12 am" src="https://user-images.githubusercontent.com/1513221/41187767-764cfa54-6b7f-11e8-9b78-0ae2f3b7526c.png">
<img width="819" alt="screen shot 2018-06-09 at 12 45 21 am" src="https://user-images.githubusercontent.com/1513221/41187764-6e045cfc-6b7f-11e8-8685-22cf7113db73.png">
